### PR TITLE
Fixed Board.printBoardState.

### DIFF
--- a/SwiftChess/Source/Board.swift
+++ b/SwiftChess/Source/Board.swift
@@ -652,7 +652,7 @@ public struct Board: Equatable {
                 case .queen:
                     character = piece.color == .white ? "Q" : "q"
                 case .king:
-                    character = piece.color == .white ? "K" : "k"
+                    character = piece.color == .white ? "G" : "g"
                 case .pawn:
                     character = piece.color == .white ? "P" : "p"
                 }


### PR DESCRIPTION
King should be printed as G/g not K/k, since K/k conflicts with knights.